### PR TITLE
helpers: fix deprecation warning 

### DIFF
--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -305,7 +305,7 @@ function format($str, array $args=array())
 
 		if (is_string($key))
 		{
-			switch ($key{0})
+			switch ($key[0])
 			{
 				case ':':
 					break;


### PR DESCRIPTION
This is a fix for PHP 7.4 (string offset access syntax with curly braces is deprecated).

Failing tests are due to unsupported PHP versions on Travis.